### PR TITLE
Create Proxmox container setup script with Alpine

### DIFF
--- a/PROXMOX.md
+++ b/PROXMOX.md
@@ -1,0 +1,295 @@
+# Freedify on Proxmox VE
+
+Run Freedify in a lightweight Alpine Linux LXC container on Proxmox VE with a single command!
+
+## 🚀 Quick Start
+
+Run this command on your Proxmox VE host:
+
+```bash
+bash -c "$(wget -qLO - https://raw.githubusercontent.com/tanujdargan/Freedify/main/proxmox-freedify-install.sh)"
+```
+
+Or using curl:
+
+```bash
+bash <(curl -s https://raw.githubusercontent.com/tanujdargan/Freedify/main/proxmox-freedify-install.sh)
+```
+
+The installer will:
+1. ✅ Download the Alpine Linux template
+2. ✅ Create an LXC container with your specifications
+3. ✅ Install Python 3, FFmpeg, and all dependencies
+4. ✅ Clone the Freedify repository
+5. ✅ Configure the service to start on boot
+6. ✅ Start Freedify automatically
+
+## 📋 Requirements
+
+- Proxmox VE 7.0 or later
+- Internet connection for downloading packages
+- Storage space for the container (recommended: 4GB minimum)
+
+## ⚙️ Container Specifications
+
+### Default Configuration
+- **OS**: Alpine Linux 3.19 (lightweight!)
+- **Disk**: 4GB
+- **RAM**: 1024MB
+- **CPU Cores**: 2
+- **Network**: DHCP (configurable)
+- **Port**: 8000 (configurable)
+
+### Resource Usage
+Alpine Linux keeps the container extremely lightweight:
+- Base OS: ~130MB
+- With Freedify installed: ~300-400MB
+- Runtime memory: ~200-500MB (depending on usage)
+
+## 🎛️ Installation Options
+
+During installation, you'll be prompted for:
+
+### Required Settings
+- **CT ID**: Container ID (auto-assigned if not specified)
+- **Container Name**: Default is "freedify"
+- **Disk Size**: Storage size in GB
+- **RAM**: Memory allocation in MB
+- **CPU Cores**: Number of CPU cores
+- **Network**: DHCP or manual IP configuration
+- **Port**: Web interface port (default: 8000)
+
+### Optional API Keys
+You can configure these during installation or add them later:
+- **Gemini API Key**: For AI Radio and DJ Mode features
+- **Genius Access Token**: For lyrics support
+- **ListenBrainz Token**: For scrobbling and recommendations
+
+## 🔧 Post-Installation
+
+### Accessing Freedify
+After installation, access Freedify at:
+```
+http://<CONTAINER_IP>:8000
+```
+
+The installer will display the container's IP address when complete.
+
+### Managing the Service
+
+#### From Proxmox Host
+```bash
+# Restart service
+pct exec <CTID> -- rc-service freedify restart
+
+# Stop service
+pct exec <CTID> -- rc-service freedify stop
+
+# Start service
+pct exec <CTID> -- rc-service freedify start
+
+# Check status
+pct exec <CTID> -- rc-service freedify status
+
+# Access container shell
+pct enter <CTID>
+```
+
+#### From Inside Container
+```bash
+# Enter the container first
+pct enter <CTID>
+
+# Then use these commands
+rc-service freedify restart
+rc-service freedify stop
+rc-service freedify start
+rc-service freedify status
+```
+
+### Adding/Updating API Keys
+
+1. Edit the environment file:
+```bash
+pct exec <CTID> -- vi /opt/freedify/.env
+```
+
+2. Add your API keys:
+```env
+GEMINI_API_KEY=your_key_here
+GENIUS_ACCESS_TOKEN=your_token_here
+LISTENBRAINZ_TOKEN=your_token_here
+SPOTIFY_CLIENT_ID=your_id_here
+SPOTIFY_CLIENT_SECRET=your_secret_here
+TICKETMASTER_API_KEY=your_key_here
+```
+
+3. Restart the service:
+```bash
+pct exec <CTID> -- rc-service freedify restart
+```
+
+## 🔄 Updating Freedify
+
+To update to the latest version of Freedify:
+
+### Option 1: Using the Update Script
+```bash
+# From Proxmox host
+bash <(curl -s https://raw.githubusercontent.com/tanujdargan/Freedify/main/proxmox-freedify-update.sh) <CTID>
+```
+
+### Option 2: Manual Update
+```bash
+# Enter the container
+pct enter <CTID>
+
+# Stop the service
+rc-service freedify stop
+
+# Update the repository
+cd /opt/freedify
+git pull origin main
+
+# Update dependencies
+pip3 install --upgrade -r app/requirements.txt --break-system-packages
+
+# Start the service
+rc-service freedify start
+```
+
+## 🐛 Troubleshooting
+
+### Service Won't Start
+```bash
+# Check service status
+pct exec <CTID> -- rc-service freedify status
+
+# Check if port is already in use
+pct exec <CTID> -- netstat -tulpn | grep 8000
+
+# Check Python dependencies
+pct exec <CTID> -- pip3 list | grep -i fastapi
+```
+
+### Can't Access Web Interface
+```bash
+# Verify container is running
+pct status <CTID>
+
+# Check container IP
+pct exec <CTID> -- hostname -i
+
+# Test from Proxmox host
+curl http://<CONTAINER_IP>:8000/api/health
+```
+
+### Container Out of Space
+```bash
+# Check disk usage
+pct exec <CTID> -- df -h
+
+# Clear cache
+pct exec <CTID> -- rm -rf /opt/freedify/cache/*
+
+# Or resize the container disk
+pct resize <CTID> rootfs +2G
+```
+
+### Update System Packages
+```bash
+pct exec <CTID> -- apk update
+pct exec <CTID> -- apk upgrade
+```
+
+## 🗑️ Uninstallation
+
+To completely remove Freedify:
+
+```bash
+# Stop and destroy the container
+pct stop <CTID>
+pct destroy <CTID>
+```
+
+## 📁 File Locations
+
+Inside the container:
+- **Application**: `/opt/freedify`
+- **Environment**: `/opt/freedify/.env`
+- **Cache**: `/opt/freedify/cache`
+- **Service**: `/etc/init.d/freedify`
+- **Logs**: Check with `rc-service freedify status`
+
+## 🔐 Security Notes
+
+1. The container runs as **unprivileged** for security
+2. Consider using a **reverse proxy** (nginx/traefik) for HTTPS
+3. **Firewall**: Only expose port 8000 to trusted networks
+4. **API Keys**: Keep your `.env` file secure and never commit it to git
+
+## 🌐 Network Configuration
+
+### Static IP Configuration
+If you chose manual IP during installation, the network is configured in:
+```bash
+pct config <CTID> | grep net0
+```
+
+To change network settings:
+```bash
+pct set <CTID> -net0 name=eth0,bridge=vmbr0,ip=192.168.1.100/24,gw=192.168.1.1
+```
+
+### Port Forwarding
+To access Freedify from outside your network, configure port forwarding on your router:
+```
+External Port: 8000 → Internal IP:Port: <CONTAINER_IP>:8000
+```
+
+Or use Proxmox port forwarding with iptables.
+
+## 💡 Advanced Configuration
+
+### Increase Cache Size
+Edit `/opt/freedify/.env`:
+```env
+MAX_CACHE_SIZE_MB=1000
+CACHE_TTL_HOURS=48
+```
+
+### Change Audio Quality
+Edit `/opt/freedify/.env`:
+```env
+MP3_BITRATE=320k  # Options: 128k, 192k, 256k, 320k
+```
+
+### Enable Auto-Start on Boot
+```bash
+pct set <CTID> -onboot 1
+```
+
+### Take Snapshots (Backup)
+```bash
+# Create a snapshot before major updates
+pct snapshot <CTID> freedify-backup-$(date +%Y%m%d)
+
+# List snapshots
+pct listsnapshot <CTID>
+
+# Rollback to snapshot
+pct rollback <CTID> <snapshot-name>
+```
+
+## 🤝 Support
+
+- **GitHub Issues**: https://github.com/tanujdargan/Freedify/issues
+- **Main README**: https://github.com/tanujdargan/Freedify/blob/main/README.md
+
+## 📝 License
+
+This installation script is provided under the MIT License, same as Freedify.
+
+---
+
+**Enjoy your lightweight, self-hosted music streaming experience!** 🎵

--- a/README.md
+++ b/README.md
@@ -260,6 +260,24 @@ Open http://localhost:8000
 
 ---
 
+## 📦 Proxmox VE LXC Container (Lightweight Self-Hosting)
+
+**Perfect for homelab enthusiasts!** Run Freedify in an ultra-lightweight Alpine Linux container with a single command.
+
+```bash
+bash <(curl -s https://raw.githubusercontent.com/tanujdargan/Freedify/main/proxmox-freedify-install.sh)
+```
+
+**Why Proxmox?**
+- ✅ **Minimal footprint**: ~300-400MB total (Alpine Linux base)
+- ✅ **Auto-configured**: Creates container, installs dependencies, and starts service
+- ✅ **Resource efficient**: Runs on just 1GB RAM and 2 CPU cores
+- ✅ **Production-ready**: Includes OpenRC service for auto-start on boot
+
+📖 **[Full Proxmox Installation Guide](PROXMOX.md)**
+
+---
+
 ## 🌐 Deploy to Railway (Recommended for Mobile + Hi-Res)
 
 **Railway is recommended** for mobile users who want Hi-Res (24-bit) streaming. Docker self-hosting is great for local networks, but Railway gives you a public URL for accessing your music from anywhere.

--- a/proxmox-freedify-install.sh
+++ b/proxmox-freedify-install.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+
+# Freedify LXC Setup Script for Proxmox VE
+# https://github.com/tanujdargan/Freedify
+#
+# Usage: bash -c "$(wget -qLO - https://raw.githubusercontent.com/tanujdargan/Freedify/main/proxmox-freedify-install.sh)"
+#
+
+# Copyright (c) 2021-2024 community-scripts
+# Author: Freedify Contributors
+# License: MIT
+
+set -e
+
+# Color codes
+RD="\033[01;31m"
+YW="\033[33m"
+GN="\033[1;92m"
+CL="\033[m"
+BFR="\\r\\033[K"
+HOLD="-"
+CM="${GN}✓${CL}"
+CROSS="${RD}✗${CL}"
+
+# Functions
+msg_info() {
+    echo -ne " ${HOLD} ${YW}$1${CL}..."
+}
+
+msg_ok() {
+    echo -e "${BFR} ${CM} ${GN}$1${CL}"
+}
+
+msg_error() {
+    echo -e "${BFR} ${CROSS} ${RD}$1${CL}"
+}
+
+# Check if running on Proxmox VE
+if ! command -v pveversion &> /dev/null; then
+    msg_error "This script must be run on Proxmox VE"
+    exit 1
+fi
+
+# Default variables
+CTID=""
+CT_NAME="freedify"
+DISK_SIZE="4"
+RAM="1024"
+CORES="2"
+BRIDGE="vmbr0"
+VLAN=""
+NET="dhcp"
+IPV4=""
+GATEWAY=""
+NETMASK=""
+DNS=""
+PORT="8000"
+STORAGE="local-lxc"
+
+# Function to get next available CTID
+get_next_ctid() {
+    local ctid=100
+    while pct status $ctid &>/dev/null; do
+        ((ctid++))
+    done
+    echo $ctid
+}
+
+# Header
+clear
+cat << "EOF"
+    ______                 ___  _____
+   / ____/_______  ___  __/ (_)/ __(_)__  __
+  / /_  / ___/ _ \/ _ \/ __ / / /_/ / / / /
+ / __/ / /  /  __/  __/ /_/ / / __/ / /_/ /
+/_/   /_/   \___/\___/\__,_/_/_/ /_/\__, /
+                                   /____/
+EOF
+echo -e "\n${GN}Proxmox VE LXC Container Setup${CL}\n"
+
+# User input
+echo -e "${YW}Container Configuration${CL}"
+read -p "Enter CT ID (default: auto): " CTID_INPUT
+CTID=${CTID_INPUT:-$(get_next_ctid)}
+
+read -p "Enter Container Name (default: freedify): " CT_NAME_INPUT
+CT_NAME=${CT_NAME_INPUT:-$CT_NAME}
+
+read -p "Enter Disk Size in GB (default: 4): " DISK_SIZE_INPUT
+DISK_SIZE=${DISK_SIZE_INPUT:-$DISK_SIZE}
+
+read -p "Enter RAM in MB (default: 1024): " RAM_INPUT
+RAM=${RAM_INPUT:-$RAM}
+
+read -p "Enter CPU Cores (default: 2): " CORES_INPUT
+CORES=${CORES_INPUT:-$CORES}
+
+read -p "Enter Bridge (default: vmbr0): " BRIDGE_INPUT
+BRIDGE=${BRIDGE_INPUT:-$BRIDGE}
+
+read -p "Enter VLAN (default: none): " VLAN_INPUT
+VLAN=${VLAN_INPUT}
+
+read -p "Use DHCP? (y/n, default: y): " USE_DHCP
+if [[ "${USE_DHCP,,}" == "n" ]]; then
+    read -p "Enter IPv4 Address (CIDR): " IPV4
+    read -p "Enter Gateway: " GATEWAY
+    NET="manual"
+fi
+
+read -p "Enter Freedify Port (default: 8000): " PORT_INPUT
+PORT=${PORT_INPUT:-$PORT}
+
+read -p "Enter Storage Location (default: local-lxc): " STORAGE_INPUT
+STORAGE=${STORAGE_INPUT:-$STORAGE}
+
+echo -e "\n${YW}Optional API Keys (press Enter to skip)${CL}"
+read -p "Gemini API Key (for AI Radio/DJ): " GEMINI_API_KEY
+read -p "Genius Access Token (for lyrics): " GENIUS_ACCESS_TOKEN
+read -p "ListenBrainz Token (for scrobbling): " LISTENBRAINZ_TOKEN
+
+# Confirmation
+echo -e "\n${YW}Container Summary:${CL}"
+echo "  CT ID:       $CTID"
+echo "  Name:        $CT_NAME"
+echo "  Disk:        ${DISK_SIZE}GB"
+echo "  RAM:         ${RAM}MB"
+echo "  Cores:       $CORES"
+echo "  Network:     $NET"
+echo "  Port:        $PORT"
+echo ""
+read -p "Continue with installation? (y/n): " CONFIRM
+if [[ "${CONFIRM,,}" != "y" ]]; then
+    msg_error "Installation cancelled"
+    exit 0
+fi
+
+# Download Alpine template
+msg_info "Downloading Alpine Linux template"
+if ! pveam list $STORAGE | grep -q "alpine-3.19-default"; then
+    pveam download $STORAGE alpine-3.19-default_20231219_amd64.tar.xz
+fi
+msg_ok "Alpine template ready"
+
+# Network configuration
+if [[ "$NET" == "dhcp" ]]; then
+    NET_CONFIG="name=eth0,bridge=$BRIDGE,ip=dhcp"
+else
+    NET_CONFIG="name=eth0,bridge=$BRIDGE,ip=$IPV4,gw=$GATEWAY"
+fi
+
+if [[ -n "$VLAN" ]]; then
+    NET_CONFIG="$NET_CONFIG,tag=$VLAN"
+fi
+
+# Create container
+msg_info "Creating LXC container"
+pct create $CTID $STORAGE:vztmpl/alpine-3.19-default_20231219_amd64.tar.xz \
+    -hostname $CT_NAME \
+    -cores $CORES \
+    -memory $RAM \
+    -swap 512 \
+    -net0 $NET_CONFIG \
+    -storage $STORAGE \
+    -rootfs $STORAGE:$DISK_SIZE \
+    -unprivileged 1 \
+    -features nesting=1 \
+    -onboot 1 \
+    -timezone host
+msg_ok "Container created (ID: $CTID)"
+
+# Start container
+msg_info "Starting container"
+pct start $CTID
+sleep 5
+msg_ok "Container started"
+
+# Function to execute commands in container
+lxc_exec() {
+    pct exec $CTID -- bash -c "$1"
+}
+
+# Update Alpine and install dependencies
+msg_info "Updating Alpine Linux"
+lxc_exec "apk update && apk upgrade"
+msg_ok "Alpine updated"
+
+msg_info "Installing system dependencies"
+lxc_exec "apk add --no-cache python3 py3-pip ffmpeg git curl ca-certificates tzdata"
+msg_ok "System dependencies installed"
+
+# Create app directory
+msg_info "Setting up Freedify"
+lxc_exec "mkdir -p /opt/freedify"
+msg_ok "App directory created"
+
+# Clone repository
+msg_info "Cloning Freedify repository"
+lxc_exec "git clone https://github.com/tanujdargan/Freedify.git /opt/freedify"
+msg_ok "Repository cloned"
+
+# Install Python dependencies
+msg_info "Installing Python dependencies (this may take a few minutes)"
+lxc_exec "cd /opt/freedify && pip3 install --no-cache-dir -r app/requirements.txt --break-system-packages"
+msg_ok "Python dependencies installed"
+
+# Create cache directory
+msg_info "Creating cache directory"
+lxc_exec "mkdir -p /opt/freedify/cache && chmod 755 /opt/freedify/cache"
+msg_ok "Cache directory created"
+
+# Create environment file
+msg_info "Configuring environment"
+ENV_CONTENT="PORT=$PORT
+MP3_BITRATE=320k
+CACHE_DIR=/opt/freedify/cache
+MAX_CACHE_SIZE_MB=500
+CACHE_TTL_HOURS=24"
+
+if [[ -n "$GEMINI_API_KEY" ]]; then
+    ENV_CONTENT="$ENV_CONTENT
+GEMINI_API_KEY=$GEMINI_API_KEY"
+fi
+
+if [[ -n "$GENIUS_ACCESS_TOKEN" ]]; then
+    ENV_CONTENT="$ENV_CONTENT
+GENIUS_ACCESS_TOKEN=$GENIUS_ACCESS_TOKEN"
+fi
+
+if [[ -n "$LISTENBRAINZ_TOKEN" ]]; then
+    ENV_CONTENT="$ENV_CONTENT
+LISTENBRAINZ_TOKEN=$LISTENBRAINZ_TOKEN"
+fi
+
+lxc_exec "cat > /opt/freedify/.env << 'ENVEOF'
+$ENV_CONTENT
+ENVEOF"
+msg_ok "Environment configured"
+
+# Create OpenRC service
+msg_info "Creating system service"
+lxc_exec "cat > /etc/init.d/freedify << 'SERVICEEOF'
+#!/sbin/openrc-run
+
+name=\"Freedify\"
+description=\"Freedify Music Streaming Service\"
+
+command=\"/usr/bin/python3\"
+command_args=\"-m uvicorn app.main:app --host 0.0.0.0 --port $PORT\"
+command_background=true
+pidfile=\"/run/freedify.pid\"
+directory=\"/opt/freedify\"
+
+depend() {
+    need net
+    after firewall
+}
+
+start_pre() {
+    checkpath --directory --mode 0755 --owner root:root /opt/freedify/cache
+}
+SERVICEEOF"
+
+lxc_exec "chmod +x /etc/init.d/freedify"
+lxc_exec "rc-update add freedify default"
+msg_ok "Service created"
+
+# Start service
+msg_info "Starting Freedify service"
+lxc_exec "rc-service freedify start"
+sleep 3
+msg_ok "Service started"
+
+# Get container IP
+if [[ "$NET" == "dhcp" ]]; then
+    sleep 5
+    CONTAINER_IP=$(pct exec $CTID -- hostname -i | awk '{print $1}')
+else
+    CONTAINER_IP=$(echo $IPV4 | cut -d'/' -f1)
+fi
+
+# Final message
+echo -e "\n${GN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${CL}"
+echo -e "${GN}  ✓ Freedify Installation Complete!${CL}"
+echo -e "${GN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${CL}"
+echo -e "\n${YW}Container Details:${CL}"
+echo -e "  • CT ID:        ${GN}$CTID${CL}"
+echo -e "  • Name:         ${GN}$CT_NAME${CL}"
+echo -e "  • IP Address:   ${GN}$CONTAINER_IP${CL}"
+echo -e "  • Port:         ${GN}$PORT${CL}"
+echo -e "\n${YW}Access Freedify:${CL}"
+echo -e "  ${GN}http://$CONTAINER_IP:$PORT${CL}"
+echo -e "\n${YW}Useful Commands:${CL}"
+echo -e "  • View logs:     ${GN}pct exec $CTID -- tail -f /var/log/freedify.log${CL}"
+echo -e "  • Restart:       ${GN}pct exec $CTID -- rc-service freedify restart${CL}"
+echo -e "  • Stop:          ${GN}pct exec $CTID -- rc-service freedify stop${CL}"
+echo -e "  • Shell access:  ${GN}pct enter $CTID${CL}"
+echo -e "\n${YW}To add API keys later:${CL}"
+echo -e "  ${GN}pct exec $CTID -- vi /opt/freedify/.env${CL}"
+echo -e "  ${GN}pct exec $CTID -- rc-service freedify restart${CL}"
+echo -e "\n${GN}Enjoy your music! 🎵${CL}\n"

--- a/proxmox-freedify-update.sh
+++ b/proxmox-freedify-update.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+
+# Freedify Update Script for Proxmox VE LXC
+# https://github.com/tanujdargan/Freedify
+#
+# Usage: Run inside the Freedify container or from Proxmox host with CTID
+#
+
+set -e
+
+# Color codes
+RD="\033[01;31m"
+YW="\033[33m"
+GN="\033[1;92m"
+CL="\033[m"
+BFR="\\r\\033[K"
+HOLD="-"
+CM="${GN}✓${CL}"
+CROSS="${RD}✗${CL}"
+
+msg_info() {
+    echo -ne " ${HOLD} ${YW}$1${CL}..."
+}
+
+msg_ok() {
+    echo -e "${BFR} ${CM} ${GN}$1${CL}"
+}
+
+msg_error() {
+    echo -e "${BFR} ${CROSS} ${RD}$1${CL}"
+}
+
+# Check if running inside container or from Proxmox host
+if [[ -f /.dockerenv ]] || [[ -f /run/.containerenv ]] || [[ -d /opt/freedify ]]; then
+    # Running inside container
+    EXEC_CMD=""
+else
+    # Running from Proxmox host
+    if [[ -z "$1" ]]; then
+        msg_error "Please provide container ID: $0 <CTID>"
+        exit 1
+    fi
+    CTID=$1
+    EXEC_CMD="pct exec $CTID --"
+    echo -e "${YW}Updating Freedify in container $CTID${CL}\n"
+fi
+
+# Stop service
+msg_info "Stopping Freedify service"
+$EXEC_CMD rc-service freedify stop 2>/dev/null || true
+msg_ok "Service stopped"
+
+# Backup current installation
+msg_info "Creating backup"
+$EXEC_CMD cp -r /opt/freedify /opt/freedify.backup.$(date +%Y%m%d_%H%M%S)
+msg_ok "Backup created"
+
+# Update repository
+msg_info "Pulling latest changes from GitHub"
+$EXEC_CMD sh -c "cd /opt/freedify && git fetch origin && git reset --hard origin/main"
+msg_ok "Repository updated"
+
+# Update system packages
+msg_info "Updating Alpine packages"
+$EXEC_CMD apk update && $EXEC_CMD apk upgrade
+msg_ok "System packages updated"
+
+# Update Python dependencies
+msg_info "Updating Python dependencies"
+$EXEC_CMD sh -c "cd /opt/freedify && pip3 install --upgrade --no-cache-dir -r app/requirements.txt --break-system-packages"
+msg_ok "Python dependencies updated"
+
+# Clear cache
+msg_info "Clearing cache"
+$EXEC_CMD rm -rf /opt/freedify/cache/*
+msg_ok "Cache cleared"
+
+# Start service
+msg_info "Starting Freedify service"
+$EXEC_CMD rc-service freedify start
+sleep 2
+msg_ok "Service started"
+
+# Check service status
+if $EXEC_CMD rc-service freedify status &>/dev/null; then
+    echo -e "\n${GN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${CL}"
+    echo -e "${GN}  ✓ Freedify Updated Successfully!${CL}"
+    echo -e "${GN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${CL}\n"
+else
+    msg_error "Service failed to start. Check logs with: pct exec $CTID -- rc-service freedify status"
+    exit 1
+fi


### PR DESCRIPTION
Add community-style Proxmox installation script for deploying Freedify in an ultra-lightweight Alpine Linux container. This enables one-command setup similar to tteck/Proxmox community scripts.

Features:
- One-line curl installation command
- Interactive setup wizard for container configuration
- Automatic Alpine Linux template download and LXC creation
- Installs Python 3, FFmpeg, and all dependencies
- Creates OpenRC service for auto-start on boot
- Supports optional API key configuration during setup
- Update script for easy upgrades
- Comprehensive documentation in PROXMOX.md

Container specs:
- OS: Alpine Linux 3.19 (~130MB base)
- Total size: ~300-400MB with Freedify
- Default resources: 1GB RAM, 2 CPU cores, 4GB disk
- Runtime memory: ~200-500MB

Usage:
`bash <(curl -s https://raw.githubusercontent.com/tanujdargan/Freedify/main/proxmox-freedify-install.sh)`